### PR TITLE
bug-fix: extend the events list lenght base on the focuseDay

### DIFF
--- a/lib/screens/calendar/calendar.dart
+++ b/lib/screens/calendar/calendar.dart
@@ -145,8 +145,8 @@ class _CalendarWidgetState extends ConsumerState<CalendarWidget> {
   }
 
   loadInputPeriodData() async {
-    var from = convertToIso8601(_focusedDay.subtract(const Duration(days: 31)));
-    var to = convertToIso8601(_focusedDay.add(const Duration(days: 31)));
+    var from = convertToIso8601(_focusedDay.subtract(const Duration(days: 40)));
+    var to = convertToIso8601(_focusedDay.add(const Duration(days: 40)));
     final client = ref.read(gqlClientProvider);
 
     _calendarPeriodFuture = client


### PR DESCRIPTION
Calendar dot for next month is missing when calendar is on current month