### PR TITLE
Feat/android language npaw

### DIFF
--- a/external_projects/bccm_player/android/src/main/kotlin/media/bcc/bccm_player/ExoPlayerController.kt
+++ b/external_projects/bccm_player/android/src/main/kotlin/media/bcc/bccm_player/ExoPlayerController.kt
@@ -164,10 +164,15 @@ class ExoPlayerController(private val context: Context) : PlayerController() {
         exoPlayer.release()
     }
 
-    override fun onIsPlayingChanged(isPlaying: Boolean) {
-        var lang = exoPlayer.audioFormat?.language
-        if (lang != null) {
-            youboraPlugin.options.contentLanguage = lang
+    override fun onTracksChanged(tracks: Tracks) {
+        for (t in tracks.groups) {
+            if (!t.isSelected) continue
+
+            if (t.type == C.TRACK_TYPE_TEXT) {
+                youboraPlugin.options.contentSubtitles = t.mediaTrackGroup.getFormat(0).language
+            } else if (t.type == C.TRACK_TYPE_AUDIO) {
+                youboraPlugin.options.contentLanguage = t.mediaTrackGroup.getFormat(0).language
+            }
         }
     }
 

--- a/external_projects/bccm_player/android/src/main/kotlin/media/bcc/bccm_player/ExoPlayerController.kt
+++ b/external_projects/bccm_player/android/src/main/kotlin/media/bcc/bccm_player/ExoPlayerController.kt
@@ -164,6 +164,13 @@ class ExoPlayerController(private val context: Context) : PlayerController() {
         exoPlayer.release()
     }
 
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        var lang = exoPlayer.audioFormat?.language
+        if (lang != null) {
+            youboraPlugin.options.contentLanguage = lang
+        }
+    }
+
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
         mediaItem?.mediaMetadata?.let { onMediaMetadataChanged(it) }
     }


### PR DESCRIPTION
## About the changes
The change introduces listens to the "onTrackChange" event that is triggered (at least) when the audio or subtitle tracks are changed, finds the currently selected track and sends the language to NPAW. It also triggers on the start of the play,  but there appears to be a gap at the very start. See screenshot.

![image](https://user-images.githubusercontent.com/398737/228843253-aba0349b-e1be-495c-b6d4-f0d6eec2cc07.png)

This is the first part of https://www.notion.so/bccmedia/Send-audio-subtitle-language-of-play-to-npaw-b79c52ecb7b141bb8479a9c90a5d08d5?pvs=4

## Discussion points
I think this is the most "correct" way of doing it. I had several other ways but they needed 2 triggers and/or extremely deep investigation into Exoplayers internals.


