### PR TITLE
Add support for sending language to NPAW

### DIFF
--- a/external_projects/bccm_player/ios/Classes/AVQueuePlayerController.swift
+++ b/external_projects/bccm_player/ios/Classes/AVQueuePlayerController.swift
@@ -189,6 +189,10 @@ public class AVQueuePlayerController: NSObject, PlayerController, AVPlayerViewCo
                             _ = playerItem.setSubtitleLanguage(subtitleLanguage)
                         }
                         
+                        // This is the initial signal. If this is not set the language is generally empty in NPAW
+                        self.youboraPlugin.options.contentSubtitles = self.player.currentItem?.getSelectedSubtitleLanguage()
+                        self.youboraPlugin.options.contentLanguage = self.player.currentItem?.getSelectedAudioLanguage()
+                        
                         completion(nil);
                     } else if (playerItem.status == .failed || playerItem.status == .unknown) {
                         print("Mediaitem failed to play")
@@ -284,7 +288,7 @@ public class AVQueuePlayerController: NSObject, PlayerController, AVPlayerViewCo
         }
         return playerItem;
     }
-    
+
     func addObservers() {
         // listening for current item change
         observers.append(player.observe(\.currentItem, options: [.old, .new]) {
@@ -298,6 +302,13 @@ public class AVQueuePlayerController: NSObject, PlayerController, AVPlayerViewCo
             self.observers.append(player.observe(\.currentItem?.duration, options: [.old, .new]) {
                 (player, change) in
                 MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyPlaybackDuration] = player.currentItem?.duration.seconds
+            })
+            
+            self.observers.append(player.observe(\.currentItem?.currentMediaSelection, options: [.old, .new]) {
+                (player, _) in
+                // Update language in NPAW
+                self.youboraPlugin.options.contentLanguage = player.currentItem?.getSelectedAudioLanguage()
+                self.youboraPlugin.options.contentSubtitles = player.currentItem?.getSelectedSubtitleLanguage()
             })
         })
         self.observers.append(player.observe(\.rate, options: [.old, .new]) {


### PR DESCRIPTION

## About the changes
Based on observing `player.currentItem.currentMediaSelection`.

This is the 2nd part of https://www.notion.so/bccmedia/Send-audio-subtitle-language-of-play-to-npaw-b79c52ecb7b141bb8479a9c90a5d08d5?pvs=4

## Discussion points
I believe the observer is added in the correct place (i.e. inside the `player.currentItem` observer, but please validate.
I had to capture a few objects but I believe they are all already captured in other observers with similar lifetimes.

